### PR TITLE
Fix missing dtype for expression

### DIFF
--- a/spec/ndx-beadl.extensions.yaml
+++ b/spec/ndx-beadl.extensions.yaml
@@ -188,6 +188,7 @@ groups:
     doc: The comment of the argument from the program
   - name: expression
     neurodata_type_inc: VectorData
+    dtype: text
     doc: The expression/value (as a string) of the argument
   - name: expression_type
     neurodata_type_inc: VectorData

--- a/src/pynwb/ndx_beadl/plot.py
+++ b/src/pynwb/ndx_beadl/plot.py
@@ -358,6 +358,7 @@ def compute_state_transition_matrix(states: Union[StatesTable, pd.DataFrame],
     num_states = len(state_types)
     state_transition_count = np.zeros(shape=(num_states, num_states), dtype=int)
     sdf = states if isinstance(states, pd.DataFrame) else states.to_dataframe(index=True)
+    sdf = sdf.sort_values(by='start_time')  # the for loop to count state transitions assumes states are sorted
     state_sequence = sdf['state_type'].to_numpy()
     for (i, j) in zip(state_sequence, state_sequence[1:]):
         state_transition_count[i][j] += 1

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -165,6 +165,7 @@ def main():
             NWBDatasetSpec(
                 name='expression',
                 neurodata_type_inc='VectorData',
+                dtype='text',
                 doc=('The expression/value (as a string) of the argument'),
             ),
             NWBDatasetSpec(


### PR DESCRIPTION
* Added missing dtype in the schema for the  ``expression`` column to ensure we can write an empty TransitionsTable
* Added sort of states by start_time to the function to compute state transition probabilities. The functional implicitly relies on that states in the StatesTable are sorted by start_time. This fix ensures that the function works even if the StateTable is not sorted in the NWB file.